### PR TITLE
Change std::endl to \n for console output

### DIFF
--- a/01-introductions.tex
+++ b/01-introductions.tex
@@ -42,7 +42,7 @@
 using namespace std;
 
 int main() {
-    cout << "Hello World!" << endl;
+    cout << "Hello World!\n";
     return 0;
 }
 \end{lstlisting}
@@ -63,7 +63,7 @@ int main() {
     cout << "Please enter your name: ";
     string name;
     cin >> name;
-    cout << "Hello " << name << "!" << endl;
+    cout << "Hello " << name << "!\n";
     return 0;
 }
 \end{lstlisting}


### PR DESCRIPTION
Suggesting `\n` instead of `std::endl` to avoid bad practise from the beginning.

`std::endl` should only be used when the programmer wants to intentionally flush the stream. This is applicable to e.g. log files, where you do not want to lose your buffered output in case the program crashes. It is a common mistake to see `std::endl` as a portable way of inserting a newline character into a stream. This mistake has also been made by many authors of C++ tutorials and books.

`std::cout << std::endl` translates to `std::cout << "\n"; std::cout.flush();`

See also: http://en.cppreference.com/w/cpp/io/manip/endl